### PR TITLE
fix: resolve all compiler warnings

### DIFF
--- a/src/IntervalTree.mbt
+++ b/src/IntervalTree.mbt
@@ -1,11 +1,11 @@
 ///|
-pub fn[V : Compare, D] new() -> T[V, D] {
+pub fn[V, D] new() -> T[V, D] {
   { root: None, size: 0, options: default_options() }
 }
 
 ///|
 /// Creates a new interval tree with options.
-pub fn[V : Compare, D] new_with_options(options : IntervalOptions) -> T[V, D] {
+pub fn[V, D] new_with_options(options : IntervalOptions) -> T[V, D] {
   { root: None, size: 0, options }
 }
 
@@ -57,7 +57,7 @@ pub fn[V : Compare, D] insert(
         node.data = data
         return false
       }
-      None => ignore(None)
+      None => ()
     }
   } // Continue with insertion
   let new_node = {
@@ -144,7 +144,7 @@ pub fn[V : Compare, D] find_overlaps_helper(
       if endpoints_overlap(left_node.max_high, query.low, interval_type) {
         find_overlaps_helper(left_node, query, results, interval_type)
       }
-    None => ignore(None)
+    None => ()
   }
 
   // Check the right subtree
@@ -154,7 +154,7 @@ pub fn[V : Compare, D] find_overlaps_helper(
       if endpoints_overlap(query.high, node.interval.low, interval_type) {
         find_overlaps_helper(right_node, query, results, interval_type)
       }
-    None => ignore(None)
+    None => ()
   }
 }
 
@@ -445,7 +445,7 @@ pub fn[V : Compare, D] find_contained_helper(
       if endpoints_leq(query.low, node.interval.low, interval_type) {
         find_contained_helper(left_node, query, results, interval_type)
       }
-    None => ignore(None)
+    None => ()
   }
 
   // Use match to check the right subtree
@@ -454,7 +454,7 @@ pub fn[V : Compare, D] find_contained_helper(
       if endpoints_geq(query.high, node.interval.high, interval_type) {
         find_contained_helper(right_node, query, results, interval_type)
       }
-    None => ignore(None)
+    None => ()
   }
 }
 
@@ -466,7 +466,7 @@ pub fn[V : Compare, D] find_contained_helper(
 pub fn[V : Compare, D] update_height_and_max_high(node : Node[V, D]) -> Unit {
   // Update height
   node.height = 1 +
-    @math.maximum(
+    @cmp.maximum(
       match node.left {
         Some(left) => left.height
         None => 0
@@ -484,14 +484,14 @@ pub fn[V : Compare, D] update_height_and_max_high(node : Node[V, D]) -> Unit {
       if left.max_high.compare(node.max_high) > 0 {
         node.max_high = left.max_high
       }
-    None => ignore(None)
+    None => ()
   }
   match node.right {
     Some(right) =>
       if right.max_high.compare(node.max_high) > 0 {
         node.max_high = right.max_high
       }
-    None => ignore(None)
+    None => ()
   }
 }
 
@@ -729,7 +729,7 @@ pub fn[T : Compare] make_interval(low : T, high : T) -> Interval[T] {
 }
 
 ///|
-pub impl[V : Show, D] Show for T[V, D] with output(self, logger) {
+pub impl[V, D] Show for T[V, D] with output(self, logger) {
   logger.write_string("IntervalTree(size=" + self.size.to_string() + ")")
 }
 
@@ -779,10 +779,7 @@ pub fn[V, D] eachi(self : T[V, D], f : (Int, Interval[V], D) -> Unit) -> Unit {
 
 ///|
 /// Implement index access for interval tree
-pub fn[V : Compare, D] op_get(
-  self : T[V, D],
-  index : Int,
-) -> IntervalMatch[V, D] {
+pub fn[V, D] op_get(self : T[V, D], index : Int) -> IntervalMatch[V, D] {
   let mut result = None
   let mut current_idx = 0
   self.each(fn(interval, data) {

--- a/src/IntervalTree.mbt
+++ b/src/IntervalTree.mbt
@@ -1,20 +1,20 @@
 ///|
-pub fn new[V : Compare, D]() -> T[V, D] {
+pub fn[V : Compare, D] new() -> T[V, D] {
   { root: None, size: 0, options: default_options() }
 }
 
 ///|
 /// Creates a new interval tree with options.
-pub fn new_with_options[V : Compare, D](options : IntervalOptions) -> T[V, D] {
+pub fn[V : Compare, D] new_with_options(options : IntervalOptions) -> T[V, D] {
   { root: None, size: 0, options }
 }
 
 ///|
 /// Creates a new interval tree with a single interval.
-pub fn singleton[V : Compare, D](
+pub fn[V : Compare, D] singleton(
   interval : Interval[V],
   data : D,
-  options~ : IntervalOptions = default_options()
+  options~ : IntervalOptions = default_options(),
 ) -> T[V, D] {
   let tree = new_with_options(options)
   ignore(tree.insert(interval, data))
@@ -23,9 +23,9 @@ pub fn singleton[V : Compare, D](
 
 ///|
 /// Creates a new interval tree from an array of intervals and data.
-pub fn from_array[V : Compare, D](
+pub fn[V : Compare, D] from_array(
   intervals : Array[(Interval[V], D)],
-  options~ : IntervalOptions = default_options()
+  options~ : IntervalOptions = default_options(),
 ) -> T[V, D] {
   let tree = new_with_options(options)
   for i in 0..<intervals.length() {
@@ -38,10 +38,10 @@ pub fn from_array[V : Compare, D](
 ///|
 /// Inserts an interval with associated data into the tree.
 /// Returns true if the interval was inserted, false if it was rejected or updated.
-pub fn insert[V : Compare, D](
+pub fn[V : Compare, D] insert(
   self : T[V, D],
   interval : Interval[V],
-  data : D
+  data : D,
 ) -> Bool {
   // Validate interval
   if is_valid_interval(interval) == false {
@@ -90,7 +90,7 @@ pub fn insert[V : Compare, D](
 ///|
 /// Removes an interval from the tree.
 /// Returns true if the interval was found and removed.
-pub fn remove[V : Compare, D](self : T[V, D], interval : Interval[V]) -> Bool {
+pub fn[V : Compare, D] remove(self : T[V, D], interval : Interval[V]) -> Bool {
   match self.root {
     None => return false
     Some(_) => {
@@ -109,9 +109,9 @@ pub fn remove[V : Compare, D](self : T[V, D], interval : Interval[V]) -> Bool {
 
 ///|
 /// Finds all intervals that overlap with the query interval.
-pub fn find_overlaps[V : Compare, D](
+pub fn[V : Compare, D] find_overlaps(
   self : T[V, D],
-  query : Interval[V]
+  query : Interval[V],
 ) -> Array[IntervalMatch[V, D]] {
   let results = []
   match self.root {
@@ -125,11 +125,11 @@ pub fn find_overlaps[V : Compare, D](
 
 ///|
 /// Finds all intervals in the subtree that overlap with the query interval.
-pub fn find_overlaps_helper[V : Compare, D](
+pub fn[V : Compare, D] find_overlaps_helper(
   node : Node[V, D],
   query : Interval[V],
   results : Array[IntervalMatch[V, D]],
-  interval_type : IntervalType
+  interval_type : IntervalType,
 ) -> Unit {
   // Check if the current node's interval overlaps with the query interval
   if intervals_overlap(node.interval, query, interval_type~) {
@@ -160,9 +160,9 @@ pub fn find_overlaps_helper[V : Compare, D](
 
 ///|
 /// Finds all intervals that are completely contained within the query interval.
-pub fn find_contained[V : Compare, D](
+pub fn[V : Compare, D] find_contained(
   self : T[V, D],
-  query : Interval[V]
+  query : Interval[V],
 ) -> Array[IntervalMatch[V, D]] {
   let results = []
   match self.root {
@@ -176,9 +176,9 @@ pub fn find_contained[V : Compare, D](
 
 ///|
 /// Finds an interval exactly matching the query.
-pub fn find_exact[V : Compare, D](
+pub fn[V : Compare, D] find_exact(
   self : T[V, D],
-  query : Interval[V]
+  query : Interval[V],
 ) -> Node[V, D]? {
   match self.root {
     None => None
@@ -188,7 +188,7 @@ pub fn find_exact[V : Compare, D](
 
 ///|
 /// Returns true if the tree contains an interval that exactly matches the query.
-pub fn contains[V : Compare, D](self : T[V, D], query : Interval[V]) -> Bool {
+pub fn[V : Compare, D] contains(self : T[V, D], query : Interval[V]) -> Bool {
   match self.find_exact(query) {
     Some(_) => true
     None => false
@@ -197,20 +197,20 @@ pub fn contains[V : Compare, D](self : T[V, D], query : Interval[V]) -> Bool {
 
 ///|
 /// Clears all intervals from the tree.
-pub fn clear[V, D](self : T[V, D]) -> Unit {
+pub fn[V, D] clear(self : T[V, D]) -> Unit {
   self.root = None
   self.size = 0
 }
 
 ///|
 /// Returns the number of intervals in the tree.
-pub fn size[V, D](self : T[V, D]) -> Int {
+pub fn[V, D] size(self : T[V, D]) -> Int {
   self.size
 }
 
 ///|
 /// Returns true if the tree is empty.
-pub fn is_empty[V, D](self : T[V, D]) -> Bool {
+pub fn[V, D] is_empty(self : T[V, D]) -> Bool {
   self.size == 0
 }
 
@@ -218,9 +218,9 @@ pub fn is_empty[V, D](self : T[V, D]) -> Bool {
 
 ///|
 /// Inserts a node into the tree.
-pub fn insert_node[V : Compare, D](
+pub fn[V : Compare, D] insert_node(
   node : Node[V, D],
-  new_node : Node[V, D]
+  new_node : Node[V, D],
 ) -> Bool {
   // Use the low endpoint of the interval as the BST key
   let comp = new_node.interval.low.compare(node.interval.low)
@@ -308,9 +308,9 @@ pub struct RemoveResult[V, D] {
 }
 
 ///|
-pub fn remove_node[V : Compare, D](
+pub fn[V : Compare, D] remove_node(
   node : Node[V, D]?,
-  interval : Interval[V]
+  interval : Interval[V],
 ) -> RemoveResult[V, D] {
   match node {
     None => { node: None, removed: false }
@@ -384,9 +384,10 @@ pub fn remove_node[V : Compare, D](
 
 ///|
 /// Finds the node with the minimum value in the subtree.
+
 ///|
 /// Finds the node with the minimum value in the subtree.
-pub fn find_min[V, D](node : Node[V, D]) -> Node[V, D] {
+pub fn[V, D] find_min(node : Node[V, D]) -> Node[V, D] {
   let mut current = node
   while true {
     match current.left {
@@ -399,9 +400,9 @@ pub fn find_min[V, D](node : Node[V, D]) -> Node[V, D] {
 
 ///|
 /// Finds a node with exactly matching interval.
-pub fn find_exact_helper[V : Compare, D](
+pub fn[V : Compare, D] find_exact_helper(
   node : Node[V, D],
-  query : Interval[V]
+  query : Interval[V],
 ) -> Node[V, D]? {
   let low_comp = query.low.compare(node.interval.low)
   if low_comp == 0 && query.high == node.interval.high {
@@ -421,13 +422,14 @@ pub fn find_exact_helper[V : Compare, D](
 }
 
 ///|
+
 ///|
 /// Finds all intervals in the subtree that are completely contained within the query interval.
-pub fn find_contained_helper[V : Compare, D](
+pub fn[V : Compare, D] find_contained_helper(
   node : Node[V, D],
   query : Interval[V],
   results : Array[IntervalMatch[V, D]],
-  interval_type : IntervalType
+  interval_type : IntervalType,
 ) -> Unit {
   // Check if the current node's interval is completely contained within the query interval
   // Check if the current node's interval is completely contained within the query interval
@@ -458,9 +460,10 @@ pub fn find_contained_helper[V : Compare, D](
 
 // This duplicate definition has been removed
 // AVL Tree balancing functions
+
 ///|
 /// Updates height and max_high values of a node.
-pub fn update_height_and_max_high[V : Compare, D](node : Node[V, D]) -> Unit {
+pub fn[V : Compare, D] update_height_and_max_high(node : Node[V, D]) -> Unit {
   // Update height
   node.height = 1 +
     @math.maximum(
@@ -494,7 +497,7 @@ pub fn update_height_and_max_high[V : Compare, D](node : Node[V, D]) -> Unit {
 
 ///|
 /// Gets the balance factor of a node.
-pub fn get_balance_factor[V, D](node : Node[V, D]) -> Int {
+pub fn[V, D] get_balance_factor(node : Node[V, D]) -> Int {
   let left_height = match node.left {
     Some(left) => left.height
     None => 0
@@ -508,7 +511,7 @@ pub fn get_balance_factor[V, D](node : Node[V, D]) -> Int {
 
 ///|
 /// Balances a node if needed.
-pub fn balance[V : Compare, D](node : Node[V, D]) -> Unit {
+pub fn[V : Compare, D] balance(node : Node[V, D]) -> Unit {
   let balance = get_balance_factor(node)
 
   // Left subtree is heavier
@@ -538,7 +541,7 @@ pub fn balance[V : Compare, D](node : Node[V, D]) -> Unit {
 
 ///|
 /// Right rotation.
-pub fn right_rotate[V : Compare, D](y : Node[V, D]) -> Unit {
+pub fn[V : Compare, D] right_rotate(y : Node[V, D]) -> Unit {
   match y.left {
     Some(x) => {
       let t2 = x.right
@@ -563,7 +566,7 @@ pub fn right_rotate[V : Compare, D](y : Node[V, D]) -> Unit {
 
 ///|
 /// Left rotation.
-pub fn left_rotate[V : Compare, D](x : Node[V, D]) -> Unit {
+pub fn[V : Compare, D] left_rotate(x : Node[V, D]) -> Unit {
   match x.right {
     Some(y) => {
       let t2 = y.left
@@ -589,16 +592,16 @@ pub fn left_rotate[V : Compare, D](x : Node[V, D]) -> Unit {
 
 ///|
 /// Checks if an interval is valid (low <= high).
-pub fn is_valid_interval[V : Compare](interval : Interval[V]) -> Bool {
+pub fn[V : Compare] is_valid_interval(interval : Interval[V]) -> Bool {
   interval.low.compare(interval.high) <= 0
 }
 
 ///|
 /// Checks if two intervals overlap.
-pub fn intervals_overlap[V : Compare](
+pub fn[V : Compare] intervals_overlap(
   a : Interval[V],
   b : Interval[V],
-  interval_type~ : IntervalType = IntervalType::Closed
+  interval_type~ : IntervalType = IntervalType::Closed,
 ) -> Bool {
   match interval_type {
     IntervalType::Closed =>
@@ -613,10 +616,10 @@ pub fn intervals_overlap[V : Compare](
 
 ///|
 /// Checks if interval a contains interval b.
-pub fn interval_contains[V : Compare](
+pub fn[V : Compare] interval_contains(
   a : Interval[V],
   b : Interval[V],
-  interval_type~ : IntervalType = IntervalType::Closed
+  interval_type~ : IntervalType = IntervalType::Closed,
 ) -> Bool {
   match interval_type {
     IntervalType::Closed =>
@@ -631,10 +634,10 @@ pub fn interval_contains[V : Compare](
 
 ///|
 /// Checks if two endpoints overlap based on interval type.
-pub fn endpoints_overlap[V : Compare](
+pub fn[V : Compare] endpoints_overlap(
   a : V,
   b : V,
-  interval_type : IntervalType
+  interval_type : IntervalType,
 ) -> Bool {
   match interval_type {
     IntervalType::Closed => a.compare(b) >= 0
@@ -646,10 +649,10 @@ pub fn endpoints_overlap[V : Compare](
 
 ///|
 /// Checks if endpoint a is less than or equal to endpoint b based on interval type.
-pub fn endpoints_leq[V : Compare](
+pub fn[V : Compare] endpoints_leq(
   a : V,
   b : V,
-  interval_type : IntervalType
+  interval_type : IntervalType,
 ) -> Bool {
   match interval_type {
     IntervalType::Closed => a.compare(b) <= 0
@@ -661,10 +664,10 @@ pub fn endpoints_leq[V : Compare](
 
 ///|
 /// Checks if endpoint a is greater than or equal to endpoint b based on interval type.
-pub fn endpoints_geq[V : Compare](
+pub fn[V : Compare] endpoints_geq(
   a : V,
   b : V,
-  interval_type : IntervalType
+  interval_type : IntervalType,
 ) -> Bool {
   match interval_type {
     IntervalType::Closed => a.compare(b) >= 0
@@ -676,7 +679,7 @@ pub fn endpoints_geq[V : Compare](
 
 ///|
 /// Converts the tree to an array of IntervalMatch objects.
-pub fn to_array[V, D](self : T[V, D]) -> Array[IntervalMatch[V, D]] {
+pub fn[V, D] to_array(self : T[V, D]) -> Array[IntervalMatch[V, D]] {
   // Get all intervals and store them in a temporary array
   let intervals_data = []
   self.each(fn(interval, data) { intervals_data.push((interval, data)) })
@@ -718,7 +721,7 @@ pub fn to_array[V, D](self : T[V, D]) -> Array[IntervalMatch[V, D]] {
 
 ///|
 /// Creates an interval with the given endpoints.
-pub fn make_interval[T : Compare](low : T, high : T) -> Interval[T] {
+pub fn[T : Compare] make_interval(low : T, high : T) -> Interval[T] {
   if low.compare(high) > 0 {
     println("Warning: Created invalid interval")
   }
@@ -732,10 +735,10 @@ pub impl[V : Show, D] Show for T[V, D] with output(self, logger) {
 
 ///|
 /// Helper function for traversing the tree in-order
-pub fn in_order_traverse[V, D, R](
+pub fn[V, D, R] in_order_traverse(
   node : Node[V, D]?,
   f : (Node[V, D]) -> R,
-  acc : R
+  acc : R,
 ) -> R {
   match node {
     None => acc
@@ -754,14 +757,14 @@ pub fn in_order_traverse[V, D, R](
 
 ///|
 /// Iterates over all intervals in the tree.
-pub fn each[V, D](self : T[V, D], f : (Interval[V], D) -> Unit) -> Unit {
+pub fn[V, D] each(self : T[V, D], f : (Interval[V], D) -> Unit) -> Unit {
   let node_f = fn(node : Node[V, D]) -> Unit { f(node.interval, node.data) }
   in_order_traverse(self.root, node_f, ())
 }
 
 ///|
 /// Iterates over all intervals in the tree with index.
-pub fn eachi[V, D](self : T[V, D], f : (Int, Interval[V], D) -> Unit) -> Unit {
+pub fn[V, D] eachi(self : T[V, D], f : (Int, Interval[V], D) -> Unit) -> Unit {
   let mut index = 0
   let node_f = fn(node : Node[V, D]) -> Unit {
     f(index, node.interval, node.data)
@@ -773,11 +776,12 @@ pub fn eachi[V, D](self : T[V, D], f : (Int, Interval[V], D) -> Unit) -> Unit {
 // Access intervals in the tree by index
 
 ///| This is a convenience method that provides index-based access to tree elements
+
 ///|
 /// Implement index access for interval tree
-pub fn op_get[V : Compare, D](
+pub fn[V : Compare, D] op_get(
   self : T[V, D],
-  index : Int
+  index : Int,
 ) -> IntervalMatch[V, D] {
   let mut result = None
   let mut current_idx = 0
@@ -788,5 +792,4 @@ pub fn op_get[V : Compare, D](
     current_idx += 1
   })
   result.unwrap()
-  
 }

--- a/src/IntervalTree.mbti
+++ b/src/IntervalTree.mbti
@@ -1,71 +1,125 @@
-fn new[V : Compare, D]() -> T[V, D]
+// Generated using `moon info`, DON'T EDIT IT
+package "kesmeey/IntervalTree"
 
-fn new_with_options[V : Compare, D](options : IntervalOptions) -> T[V, D]
+// Values
+fn[V : Compare, D] balance(Node[V, D]) -> Unit
 
-fn singleton[V : Compare, D](interval : Interval[V], data : D, options~ : IntervalOptions = default_options()) -> T[V, D]
+fn default_options() -> IntervalOptions
 
-fn from_array[V : Compare, D](intervals : Array[(Interval[V], D)], options~ : IntervalOptions = default_options()) -> T[V, D]
+fn[V : Compare] endpoints_geq(V, V, IntervalType) -> Bool
 
-fn insert[V : Compare, D](self : T[V, D], interval : Interval[V], data : D) -> Bool
+fn[V : Compare] endpoints_leq(V, V, IntervalType) -> Bool
 
-fn remove[V : Compare, D](self : T[V, D], interval : Interval[V]) -> Bool
+fn[V : Compare] endpoints_overlap(V, V, IntervalType) -> Bool
 
-fn find_overlaps[V : Compare, D](self : T[V, D], query : Interval[V]) -> Array[IntervalMatch[V, D]]
+fn[V : Compare, D] find_contained_helper(Node[V, D], Interval[V], Array[IntervalMatch[V, D]], IntervalType) -> Unit
 
-fn find_overlaps_helper[V : Compare, D](node : Node[V, D], query : Interval[V], results : Array[IntervalMatch[V, D]], interval_type : IntervalType) -> Unit
+fn[V : Compare, D] find_exact_helper(Node[V, D], Interval[V]) -> Node[V, D]?
 
-fn find_contained[V : Compare, D](self : T[V, D], query : Interval[V]) -> Array[IntervalMatch[V, D]]
+fn[V, D] find_min(Node[V, D]) -> Node[V, D]
 
-fn find_exact[V : Compare, D](self : T[V, D], query : Interval[V]) -> Node[V, D]?
+fn[V : Compare, D] find_overlaps_helper(Node[V, D], Interval[V], Array[IntervalMatch[V, D]], IntervalType) -> Unit
 
-fn contains[V : Compare, D](self : T[V, D], query : Interval[V]) -> Bool
+fn[V : Compare, D] from_array(Array[(Interval[V], D)], options? : IntervalOptions) -> T[V, D]
 
-fn clear[V, D](self : T[V, D]) -> Unit
+fn[V, D] get_balance_factor(Node[V, D]) -> Int
 
-fn size[V, D](self : T[V, D]) -> Int
+fn[V, D, R] in_order_traverse(Node[V, D]?, (Node[V, D]) -> R, R) -> R
 
-fn is_empty[V, D](self : T[V, D]) -> Bool
+fn[V : Compare, D] insert_node(Node[V, D], Node[V, D]) -> Bool
 
-fn insert_node[V : Compare, D](node : Node[V, D], new_node : Node[V, D]) -> Bool
+fn[V : Compare] interval_contains(Interval[V], Interval[V], interval_type? : IntervalType) -> Bool
 
-fn remove_node[V : Compare, D](node : Node[V, D]?, interval : Interval[V]) -> RemoveResult[V, D]
+fn[V : Compare] intervals_overlap(Interval[V], Interval[V], interval_type? : IntervalType) -> Bool
 
-fn find_min[V, D](node : Node[V, D]) -> Node[V, D]
+fn[V : Compare] is_valid_interval(Interval[V]) -> Bool
 
-fn find_exact_helper[V : Compare, D](node : Node[V, D], query : Interval[V]) -> Node[V, D]?
+fn[V : Compare, D] left_rotate(Node[V, D]) -> Unit
 
-fn find_contained_helper[V : Compare, D](node : Node[V, D], query : Interval[V], results : Array[IntervalMatch[V, D]], interval_type : IntervalType) -> Unit
+fn[T : Compare] make_interval(T, T) -> Interval[T]
 
-fn update_height_and_max_high[V : Compare, D](node : Node[V, D]) -> Unit
+fn[V : Compare, D] new() -> T[V, D]
 
-fn get_balance_factor[V, D](node : Node[V, D]) -> Int
+fn[V : Compare, D] new_with_options(IntervalOptions) -> T[V, D]
 
-fn balance[V : Compare, D](node : Node[V, D]) -> Unit
+fn[V : Compare, D] remove_node(Node[V, D]?, Interval[V]) -> RemoveResult[V, D]
 
-fn right_rotate[V : Compare, D](y : Node[V, D]) -> Unit
+fn[V : Compare, D] right_rotate(Node[V, D]) -> Unit
 
-fn left_rotate[V : Compare, D](x : Node[V, D]) -> Unit
+fn[V : Compare, D] singleton(Interval[V], D, options? : IntervalOptions) -> T[V, D]
 
-fn is_valid_interval[V : Compare](interval : Interval[V]) -> Bool
+fn[V : Compare, D] update_height_and_max_high(Node[V, D]) -> Unit
 
-fn intervals_overlap[V : Compare](a : Interval[V], b : Interval[V], interval_type~ : IntervalType = IntervalType::Closed) -> Bool
+// Errors
 
-fn interval_contains[V : Compare](a : Interval[V], b : Interval[V], interval_type~ : IntervalType = IntervalType::Closed) -> Bool
+// Types and methods
+pub struct Interval[T] {
+  low : T
+  high : T
+}
+impl[T : Eq] Eq for Interval[T]
+impl[T : Show] Show for Interval[T]
 
-fn endpoints_overlap[V : Compare](a : V, b : V, interval_type : IntervalType) -> Bool
+pub struct IntervalMatch[T, D] {
+  interval : Interval[T]
+  data : D
+}
+impl[T : Eq, D : Eq] Eq for IntervalMatch[T, D]
+impl[T : Show, D : Show] Show for IntervalMatch[T, D]
 
-fn endpoints_leq[V : Compare](a : V, b : V, interval_type : IntervalType) -> Bool
+pub struct IntervalOptions {
+  interval_type : IntervalType
+  allow_duplicates : Bool
+}
+impl Eq for IntervalOptions
+impl Show for IntervalOptions
 
-fn endpoints_geq[V : Compare](a : V, b : V, interval_type : IntervalType) -> Bool
+pub(all) enum IntervalType {
+  Closed
+  Open
+  LeftClosed
+  RightClosed
+}
+impl Eq for IntervalType
+impl Show for IntervalType
 
-fn to_array[V, D](self : T[V, D]) -> Array[IntervalMatch[V, D]]
+pub struct Node[V, D] {
+  mut interval : Interval[V]
+  mut data : D
+  mut max_high : V
+  mut left : Node[V, D]?
+  mut right : Node[V, D]?
+  mut height : Int
+}
+impl[V : Eq, D : Eq] Eq for Node[V, D]
+impl[V : Show, D : Show] Show for Node[V, D]
 
-fn make_interval[T : Compare](low : T, high : T) -> Interval[T]
+pub struct RemoveResult[V, D] {
+  node : Node[V, D]?
+  removed : Bool
+}
 
-fn in_order_traverse[V, D, R](node : Node[V, D]?, f : (Node[V, D]) -> R, acc : R) -> R
+pub struct T[V, D] {
+  mut root : Node[V, D]?
+  mut size : Int
+  options : IntervalOptions
+}
+fn[V, D] T::clear(Self[V, D]) -> Unit
+fn[V : Compare, D] T::contains(Self[V, D], Interval[V]) -> Bool
+fn[V, D] T::each(Self[V, D], (Interval[V], D) -> Unit) -> Unit
+fn[V, D] T::eachi(Self[V, D], (Int, Interval[V], D) -> Unit) -> Unit
+fn[V : Compare, D] T::find_contained(Self[V, D], Interval[V]) -> Array[IntervalMatch[V, D]]
+fn[V : Compare, D] T::find_exact(Self[V, D], Interval[V]) -> Node[V, D]?
+fn[V : Compare, D] T::find_overlaps(Self[V, D], Interval[V]) -> Array[IntervalMatch[V, D]]
+fn[V : Compare, D] T::insert(Self[V, D], Interval[V], D) -> Bool
+fn[V, D] T::is_empty(Self[V, D]) -> Bool
+fn[V : Compare, D] T::op_get(Self[V, D], Int) -> IntervalMatch[V, D]
+fn[V : Compare, D] T::remove(Self[V, D], Interval[V]) -> Bool
+fn[V, D] T::size(Self[V, D]) -> Int
+fn[V, D] T::to_array(Self[V, D]) -> Array[IntervalMatch[V, D]]
+impl[V : Show, D] Show for T[V, D]
 
-fn each[V, D](self : T[V, D], f : (Interval[V], D) -> Unit) -> Unit
+// Type aliases
 
-fn eachi[V, D](self : T[V, D], f : (Int, Interval[V], D) -> Unit) -> Unit
+// Traits
 
-fn op_get[V : Compare, D](self : T[V, D], index : Int) -> IntervalMatch[V, D]

--- a/src/IntervalTree.mbti
+++ b/src/IntervalTree.mbti
@@ -38,9 +38,9 @@ fn[V : Compare, D] left_rotate(Node[V, D]) -> Unit
 
 fn[T : Compare] make_interval(T, T) -> Interval[T]
 
-fn[V : Compare, D] new() -> T[V, D]
+fn[V, D] new() -> T[V, D]
 
-fn[V : Compare, D] new_with_options(IntervalOptions) -> T[V, D]
+fn[V, D] new_with_options(IntervalOptions) -> T[V, D]
 
 fn[V : Compare, D] remove_node(Node[V, D]?, Interval[V]) -> RemoveResult[V, D]
 
@@ -113,11 +113,11 @@ fn[V : Compare, D] T::find_exact(Self[V, D], Interval[V]) -> Node[V, D]?
 fn[V : Compare, D] T::find_overlaps(Self[V, D], Interval[V]) -> Array[IntervalMatch[V, D]]
 fn[V : Compare, D] T::insert(Self[V, D], Interval[V], D) -> Bool
 fn[V, D] T::is_empty(Self[V, D]) -> Bool
-fn[V : Compare, D] T::op_get(Self[V, D], Int) -> IntervalMatch[V, D]
+fn[V, D] T::op_get(Self[V, D], Int) -> IntervalMatch[V, D]
 fn[V : Compare, D] T::remove(Self[V, D], Interval[V]) -> Bool
 fn[V, D] T::size(Self[V, D]) -> Int
 fn[V, D] T::to_array(Self[V, D]) -> Array[IntervalMatch[V, D]]
-impl[V : Show, D] Show for T[V, D]
+impl[V, D] Show for T[V, D]
 
 // Type aliases
 

--- a/src/IntervalTree_test.mbt
+++ b/src/IntervalTree_test.mbt
@@ -1,22 +1,22 @@
 ///|
 test "new_empty_tree" {
   let tree : T[Int, String] = @IntervalTree.new()
-  assert_eq!(tree.size(), 0)
-  assert_eq!(tree.is_empty(), true)
+  assert_eq(tree.size(), 0)
+  assert_eq(tree.is_empty(), true)
 }
 
 ///|
 test "insert_and_find" {
   let tree : T[Int, String] = @IntervalTree.new()
   let p1 = tree.insert(@IntervalTree.make_interval(10, 20), "A")
-  assert_eq!(p1, true)
-  assert_eq!(tree.size(), 1)
+  assert_eq(p1, true)
+  assert_eq(tree.size(), 1)
   let p2 = tree.insert(@IntervalTree.make_interval(15, 25), "B")
-  assert_eq!(p2, true)
-  assert_eq!(tree.size(), 2)
+  assert_eq(p2, true)
+  assert_eq(tree.size(), 2)
   let p3 = tree.insert(@IntervalTree.make_interval(5, 15), "C")
-  assert_eq!(p3, true)
-  assert_eq!(tree.size(), 3)
+  assert_eq(p3, true)
+  assert_eq(tree.size(), 3)
 }
 
 ///|
@@ -28,10 +28,10 @@ test "find_overlaps" {
   ignore(tree.insert(@IntervalTree.make_interval(30, 40), "D"))
   let query = @IntervalTree.make_interval(12, 18)
   let overlaps = tree.find_overlaps(query)
-  assert_eq!(overlaps.length(), 3)
+  assert_eq(overlaps.length(), 3)
   let no_overlap_query = @IntervalTree.make_interval(26, 29)
   let no_results = tree.find_overlaps(no_overlap_query)
-  assert_eq!(no_results.length(), 0)
+  assert_eq(no_results.length(), 0)
 }
 
 ///|
@@ -42,10 +42,10 @@ test "find_contained" {
   ignore(tree.insert(@IntervalTree.make_interval(5, 30), "C"))
   let query = @IntervalTree.make_interval(5, 30)
   let contained = tree.find_contained(query)
-  assert_eq!(contained.length(), 3)
+  assert_eq(contained.length(), 3)
   let query2 = @IntervalTree.make_interval(9, 21)
   let contained2 = tree.find_contained(query2)
-  assert_eq!(contained2.length(), 2)
+  assert_eq(contained2.length(), 2)
 }
 
 ///|
@@ -56,18 +56,18 @@ test "remove_intervals" {
   ignore(tree.insert(@IntervalTree.make_interval(10, 20), "A"))
   ignore(tree.insert(@IntervalTree.make_interval(15, 25), "B"))
   ignore(tree.insert(@IntervalTree.make_interval(5, 15), "C"))
-  assert_eq!(tree.size(), 3)
+  assert_eq(tree.size(), 3)
 
   // Remove existing interval
   let removed = tree.remove(@IntervalTree.make_interval(10, 20))
-  assert_eq!(removed, true)
-  assert_eq!(tree.size(), 2)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(10, 20)), false)
+  assert_eq(removed, true)
+  assert_eq(tree.size(), 2)
+  assert_eq(tree.contains(@IntervalTree.make_interval(10, 20)), false)
 
   // Try to remove non-existing interval
   let not_removed = tree.remove(@IntervalTree.make_interval(10, 20))
-  assert_eq!(not_removed, false)
-  assert_eq!(tree.size(), 2)
+  assert_eq(not_removed, false)
+  assert_eq(tree.size(), 2)
 }
 
 ///|
@@ -77,13 +77,13 @@ test "clear_tree" {
   // Add intervals - modified to use ignore
   ignore(tree.insert(@IntervalTree.make_interval(10, 20), "A"))
   ignore(tree.insert(@IntervalTree.make_interval(15, 25), "B"))
-  assert_eq!(tree.size(), 2)
+  assert_eq(tree.size(), 2)
 
   // Clear the tree
   tree.clear()
-  assert_eq!(tree.size(), 0)
-  assert_eq!(tree.is_empty(), true)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(10, 20)), false)
+  assert_eq(tree.size(), 0)
+  assert_eq(tree.is_empty(), true)
+  assert_eq(tree.contains(@IntervalTree.make_interval(10, 20)), false)
 }
 
 ///|
@@ -98,11 +98,11 @@ test "each_method" {
     intervals.push((interval.low, interval.high))
     data.push(value)
   })
-  assert_eq!(intervals.length(), 3)
-  assert_eq!(data.length(), 3)
-  assert_eq!(data.contains("A"), true)
-  assert_eq!(data.contains("B"), true)
-  assert_eq!(data.contains("C"), true)
+  assert_eq(intervals.length(), 3)
+  assert_eq(data.length(), 3)
+  assert_eq(data.contains("A"), true)
+  assert_eq(data.contains("B"), true)
+  assert_eq(data.contains("C"), true)
 }
 
 ///|
@@ -119,8 +119,8 @@ test "eachi_method" {
     intervals.push((interval.low, interval.high))
     data.push(value)
   })
-  assert_eq!(indices, [0, 1, 2])
-  assert_eq!(data.length(), 3)
+  assert_eq(indices, [0, 1, 2])
+  assert_eq(data.length(), 3)
 }
 
 ///|
@@ -129,17 +129,17 @@ test "to_array_method" {
   ignore(tree.insert(@IntervalTree.make_interval(10, 20), "A"))
   ignore(tree.insert(@IntervalTree.make_interval(15, 25), "B"))
   let array = tree.to_array()
-  assert_eq!(array.length(), 2)
-  assert_eq!(array[0].data == "A" || array[1].data == "A", true)
-  assert_eq!(array[0].data == "B" || array[1].data == "B", true)
+  assert_eq(array.length(), 2)
+  assert_eq(array[0].data == "A" || array[1].data == "A", true)
+  assert_eq(array[0].data == "B" || array[1].data == "B", true)
 }
 
 ///|
 test "singleton_constructor" {
   let interval = @IntervalTree.make_interval(10, 20)
   let tree = @IntervalTree.singleton(interval, "data")
-  assert_eq!(tree.size(), 1)
-  assert_eq!(tree.contains(interval), true)
+  assert_eq(tree.size(), 1)
+  assert_eq(tree.contains(interval), true)
 }
 
 ///|
@@ -150,10 +150,10 @@ test "from_array_constructor" {
     (@IntervalTree.make_interval(5, 15), "C"),
   ]
   let tree = @IntervalTree.from_array(intervals)
-  assert_eq!(tree.size(), 3)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(10, 20)), true)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(15, 25)), true)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(5, 15)), true)
+  assert_eq(tree.size(), 3)
+  assert_eq(tree.contains(@IntervalTree.make_interval(10, 20)), true)
+  assert_eq(tree.contains(@IntervalTree.make_interval(15, 25)), true)
+  assert_eq(tree.contains(@IntervalTree.make_interval(5, 15)), true)
 }
 
 ///|
@@ -165,21 +165,21 @@ test "op_get_method" {
   let match0 = tree[0]
   let match1 = tree[1]
   let match2 = tree[2]
-  assert_eq!(
+  assert_eq(
     match0.data == "A" || match0.data == "B" || match0.data == "C",
     true,
   )
-  assert_eq!(
+  assert_eq(
     match1.data == "A" || match1.data == "B" || match1.data == "C",
     true,
   )
-  assert_eq!(
+  assert_eq(
     match2.data == "A" || match2.data == "B" || match2.data == "C",
     true,
   )
 
   // Test that the indices are unique
-  assert_eq!(
+  assert_eq(
     match0.data != match1.data &&
     match1.data != match2.data &&
     match0.data != match2.data,
@@ -192,34 +192,34 @@ test "different_value_types" {
   // Test with Float values
   let float_tree : T[Float, String] = @IntervalTree.new()
   ignore(float_tree.insert(@IntervalTree.make_interval(10.5, 20.5), "A"))
-  assert_eq!(float_tree.size(), 1)
+  assert_eq(float_tree.size(), 1)
 
   // Test with String values
   let string_tree : T[String, Int] = @IntervalTree.new()
   ignore(string_tree.insert(@IntervalTree.make_interval("a", "z"), 1))
-  assert_eq!(string_tree.size(), 1)
-  assert_eq!(string_tree.contains(@IntervalTree.make_interval("a", "z")), true)
+  assert_eq(string_tree.size(), 1)
+  assert_eq(string_tree.contains(@IntervalTree.make_interval("a", "z")), true)
 }
 
 ///|
 test "new_empty_tree" {
   let tree : T[Int, String] = @IntervalTree.new()
-  assert_eq!(tree.size(), 0)
-  assert_eq!(tree.is_empty(), true)
+  assert_eq(tree.size(), 0)
+  assert_eq(tree.is_empty(), true)
 }
 
 ///|
 test "insert_and_find" {
   let tree : T[Int, String] = @IntervalTree.new()
   let p1 = tree.insert(@IntervalTree.make_interval(10, 20), "A")
-  assert_eq!(p1, true)
-  assert_eq!(tree.size(), 1)
+  assert_eq(p1, true)
+  assert_eq(tree.size(), 1)
   let p2 = tree.insert(@IntervalTree.make_interval(15, 25), "B")
-  assert_eq!(p2, true)
-  assert_eq!(tree.size(), 2)
+  assert_eq(p2, true)
+  assert_eq(tree.size(), 2)
   let p3 = tree.insert(@IntervalTree.make_interval(5, 15), "C")
-  assert_eq!(p3, true)
-  assert_eq!(tree.size(), 3)
+  assert_eq(p3, true)
+  assert_eq(tree.size(), 3)
 }
 
 ///|
@@ -235,12 +235,12 @@ test "find_overlaps" {
   // Test overlap query
   let query = @IntervalTree.make_interval(12, 18)
   let overlaps = tree.find_overlaps(query)
-  assert_eq!(overlaps.length(), 3) // Should find A, B, C
+  assert_eq(overlaps.length(), 3) // Should find A, B, C
 
   // Test query with no overlaps
   let no_overlap_query = @IntervalTree.make_interval(26, 29)
   let no_results = tree.find_overlaps(no_overlap_query)
-  assert_eq!(no_results.length(), 0)
+  assert_eq(no_results.length(), 0)
 }
 
 ///|
@@ -255,10 +255,10 @@ test "find_contained" {
   // Test containment query
   let query = @IntervalTree.make_interval(5, 30)
   let contained = tree.find_contained(query)
-  assert_eq!(contained.length(), 3) // Should find all intervals
+  assert_eq(contained.length(), 3) // Should find all intervals
   let query2 = @IntervalTree.make_interval(9, 21)
   let contained2 = tree.find_contained(query2)
-  assert_eq!(contained2.length(), 2) // Should find A and B
+  assert_eq(contained2.length(), 2) // Should find A and B
 }
 
 ///|
@@ -269,18 +269,18 @@ test "remove_intervals" {
   ignore(tree.insert(@IntervalTree.make_interval(10, 20), "A"))
   ignore(tree.insert(@IntervalTree.make_interval(15, 25), "B"))
   ignore(tree.insert(@IntervalTree.make_interval(5, 15), "C"))
-  assert_eq!(tree.size(), 3)
+  assert_eq(tree.size(), 3)
 
   // Remove existing interval
   let removed = tree.remove(@IntervalTree.make_interval(10, 20))
-  assert_eq!(removed, true)
-  assert_eq!(tree.size(), 2)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(10, 20)), false)
+  assert_eq(removed, true)
+  assert_eq(tree.size(), 2)
+  assert_eq(tree.contains(@IntervalTree.make_interval(10, 20)), false)
 
   // Try to remove non-existing interval
   let not_removed = tree.remove(@IntervalTree.make_interval(10, 20))
-  assert_eq!(not_removed, false)
-  assert_eq!(tree.size(), 2)
+  assert_eq(not_removed, false)
+  assert_eq(tree.size(), 2)
 }
 
 ///|
@@ -290,13 +290,13 @@ test "clear_tree" {
   // Add intervals - modified to use ignore
   ignore(tree.insert(@IntervalTree.make_interval(10, 20), "A"))
   ignore(tree.insert(@IntervalTree.make_interval(15, 25), "B"))
-  assert_eq!(tree.size(), 2)
+  assert_eq(tree.size(), 2)
 
   // Clear the tree
   tree.clear()
-  assert_eq!(tree.size(), 0)
-  assert_eq!(tree.is_empty(), true)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(10, 20)), false)
+  assert_eq(tree.size(), 0)
+  assert_eq(tree.is_empty(), true)
+  assert_eq(tree.contains(@IntervalTree.make_interval(10, 20)), false)
 }
 
 ///|
@@ -311,11 +311,11 @@ test "each_method" {
     intervals.push((interval.low, interval.high))
     data.push(value)
   })
-  assert_eq!(intervals.length(), 3)
-  assert_eq!(data.length(), 3)
-  assert_eq!(data.contains("A"), true)
-  assert_eq!(data.contains("B"), true)
-  assert_eq!(data.contains("C"), true)
+  assert_eq(intervals.length(), 3)
+  assert_eq(data.length(), 3)
+  assert_eq(data.contains("A"), true)
+  assert_eq(data.contains("B"), true)
+  assert_eq(data.contains("C"), true)
 }
 
 ///|
@@ -332,8 +332,8 @@ test "eachi_method" {
     intervals.push((interval.low, interval.high))
     data.push(value)
   })
-  assert_eq!(indices, [0, 1, 2])
-  assert_eq!(data.length(), 3)
+  assert_eq(indices, [0, 1, 2])
+  assert_eq(data.length(), 3)
 }
 
 ///|
@@ -342,17 +342,17 @@ test "to_array_method" {
   ignore(tree.insert(@IntervalTree.make_interval(10, 20), "A"))
   ignore(tree.insert(@IntervalTree.make_interval(15, 25), "B"))
   let array = tree.to_array()
-  assert_eq!(array.length(), 2)
-  assert_eq!(array[0].data == "A" || array[1].data == "A", true)
-  assert_eq!(array[0].data == "B" || array[1].data == "B", true)
+  assert_eq(array.length(), 2)
+  assert_eq(array[0].data == "A" || array[1].data == "A", true)
+  assert_eq(array[0].data == "B" || array[1].data == "B", true)
 }
 
 ///|
 test "singleton_constructor" {
   let interval = @IntervalTree.make_interval(10, 20)
   let tree = @IntervalTree.singleton(interval, "data")
-  assert_eq!(tree.size(), 1)
-  assert_eq!(tree.contains(interval), true)
+  assert_eq(tree.size(), 1)
+  assert_eq(tree.contains(interval), true)
 }
 
 ///|
@@ -363,10 +363,10 @@ test "from_array_constructor" {
     (@IntervalTree.make_interval(5, 15), "C"),
   ]
   let tree = @IntervalTree.from_array(intervals)
-  assert_eq!(tree.size(), 3)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(10, 20)), true)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(15, 25)), true)
-  assert_eq!(tree.contains(@IntervalTree.make_interval(5, 15)), true)
+  assert_eq(tree.size(), 3)
+  assert_eq(tree.contains(@IntervalTree.make_interval(10, 20)), true)
+  assert_eq(tree.contains(@IntervalTree.make_interval(15, 25)), true)
+  assert_eq(tree.contains(@IntervalTree.make_interval(5, 15)), true)
 }
 
 ///|
@@ -378,21 +378,21 @@ test "op_get_method" {
   let match0 = tree[0]
   let match1 = tree[1]
   let match2 = tree[2]
-  assert_eq!(
+  assert_eq(
     match0.data == "A" || match0.data == "B" || match0.data == "C",
     true,
   )
-  assert_eq!(
+  assert_eq(
     match1.data == "A" || match1.data == "B" || match1.data == "C",
     true,
   )
-  assert_eq!(
+  assert_eq(
     match2.data == "A" || match2.data == "B" || match2.data == "C",
     true,
   )
 
   // Test that the indices are unique
-  assert_eq!(
+  assert_eq(
     match0.data != match1.data &&
     match1.data != match2.data &&
     match0.data != match2.data,
@@ -405,13 +405,13 @@ test "different_value_types" {
   // Test with Float values
   let float_tree : T[Float, String] = @IntervalTree.new()
   ignore(float_tree.insert(@IntervalTree.make_interval(10.5, 20.5), "A"))
-  assert_eq!(float_tree.size(), 1)
+  assert_eq(float_tree.size(), 1)
 
   // Test with String values
   let string_tree : T[String, Int] = @IntervalTree.new()
   ignore(string_tree.insert(@IntervalTree.make_interval("a", "z"), 1))
-  assert_eq!(string_tree.size(), 1)
-  assert_eq!(string_tree.contains(@IntervalTree.make_interval("a", "z")), true)
+  assert_eq(string_tree.size(), 1)
+  assert_eq(string_tree.contains(@IntervalTree.make_interval("a", "z")), true)
 }
 
 ///|
@@ -425,7 +425,7 @@ test "test_different_interval_types" {
   ignore(open_tree.insert(@IntervalTree.make_interval(10, 20), "A"))
   let open_query = @IntervalTree.make_interval(20, 30)
   let open_results = open_tree.find_overlaps(open_query)
-  assert_eq!(open_results.length(), 0) // In open interval type, (10,20) doesn't overlap with (20,30)
+  assert_eq(open_results.length(), 0) // In open interval type, (10,20) doesn't overlap with (20,30)
 
   // Test closed intervals
   let closed_option = IntervalOptions::{
@@ -438,5 +438,5 @@ test "test_different_interval_types" {
   ignore(closed_tree.insert(@IntervalTree.make_interval(10, 20), "A"))
   let closed_query = @IntervalTree.make_interval(20, 30)
   let closed_results = closed_tree.find_overlaps(closed_query)
-  assert_eq!(closed_results.length(), 1) // In closed interval type, [10,20] overlaps with [20,30]
+  assert_eq(closed_results.length(), 1) // In closed interval type, [10,20] overlaps with [20,30]
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This commit fixes all MoonBit compiler warnings in the project:

1. Remove unused trait bounds:
   - Remove `V : Compare` from `new()` and `new_with_options()` functions
   - Remove `V : Show` from Show implementation for T[V,D]
   - Remove `V : Compare` from `op_get()` function

2. Fix unresolved type variable warnings:
   - Replace all instances of `ignore(None)` with `()` to provide proper type

3. Fix deprecation warning:
   - Replace deprecated `@math.maximum` with `@cmp.maximum`

All tests continue to pass after these changes, ensuring no functionality was affected.